### PR TITLE
Add glewInit() when USING_GLEW is defined

### DIFF
--- a/lib/fosphor/gl.c
+++ b/lib/fosphor/gl.c
@@ -254,6 +254,15 @@ fosphor_gl_init(struct fosphor *self)
 
 	self->gl = gl;
 
+#ifdef USING_GLEW
+	GLenum err = glewInit();
+	if (GLEW_OK != err)
+	{
+	  /* Problem: glewInit failed, something is seriously wrong. */
+	  fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
+	}
+#endif
+	
 	memset(gl, 0, sizeof(struct fosphor_gl_state));
 
 	/* Font */


### PR DESCRIPTION
To get to compile on windows and the AMD SDK, glew was required.  This will add an init call if and only if it is compiled with the USING_GLEW macro manually defined during build.

Note: I'm not an OpenGL expert, so there may be a better method to achieve my end that this... but it worked for me.
